### PR TITLE
Fix React

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,7 @@
 import os from 'os'
 import fs from 'fs'
 import path from 'path'
+import crypto from 'crypto'
 import { minify } from 'terser'
 import { make } from './elm-watch/src/SpawnElm.js'
 import { inject } from './elm-watch/src/Inject.js'
@@ -91,7 +92,7 @@ export default function elmWatchPlugin(opts = {}) {
         }
 
         let tmpDir = os.tmpdir()
-        let tempOutputFilepath = path.join(tmpDir, 'out.js')
+        let tempOutputFilepath = path.join(tmpDir, `${sha256(id)}.js`)
 
         if (isReactComponent && compilationMode === 'debug') {
           compilationMode = 'standard'
@@ -231,6 +232,8 @@ export default function elmWatchPlugin(opts = {}) {
     }
   }
 }
+
+const sha256 = (string) => crypto.createHash('sha256').update(string).digest('hex')
 
 /**
  * Makes it easier to work with multiple entrypoints by turning 


### PR DESCRIPTION
Steps to reproduce:

1. `cd examples/06-react-app/`
2. `npm run dev`
3. open the site in the browser

Result: `Uncaught TypeError: can't access property "__elmModulePath", obj is undefined`

Reason: The React example has two Elm components: Counter and Logo. Both are compiled in parallel – both to `/tmp/out.js`. Both of them end up getting the compiled code Elm JS for Logo. For Counter, the `denest` code then tries to read `Elm.Components.Counter`, but only `Elm.Components.Logo` exists.

Fix: Write to different temp files for each module. To avoid creating excessive amounts of temp files, I sha256 hash the module path and use that as the temp file name. Then we get just one temp file per module.