### PR TITLE
Fix patching

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -415,7 +415,7 @@ const REPLACEMENT_REGEX = /^((?:function (_Platform_initialize|_VirtualDom_apply
 const REPLACEMENTS = {
   // Keep track of the last rendered node, so we can access it in `app.unmount`.
   // Inspired by https://github.com/lamdera/compiler/blob/b3514260acecbedb3289d7f0c7386dcf174de59a/extra/Lamdera/Injection.hs#L712-L722
-  _VirtualDom_applyPatches: (code) => `var _VirtualDom_lastDomNode = null; ${code.replace(/return/g, "return _VirtualDom_lastDomNode =")}`,
+  _VirtualDom_applyPatches: (code) => `var _VirtualDom_lastDomNode = null;\n${code.replace(/return/g, "return _VirtualDom_lastDomNode =")}`,
 
   // Add `app.unmount` to programs. The steps are:
   // 1. Render one last time, synchronously, in case there is a scheduled

--- a/src/index.js
+++ b/src/index.js
@@ -414,6 +414,7 @@ const REPLACEMENT_REGEX = /^((?:function (_Platform_initialize|_VirtualDom_apply
 
 const REPLACEMENTS = {
   // Keep track of the last rendered node, so we can access it in `app.unmount`.
+  // Inspired by https://github.com/lamdera/compiler/blob/b3514260acecbedb3289d7f0c7386dcf174de59a/extra/Lamdera/Injection.hs#L712-L722
   _VirtualDom_applyPatches: (code) => `var _VirtualDom_lastDomNode = null; ${code.replace(/return/g, "return _VirtualDom_lastDomNode =")}`,
 
   // Add `app.unmount` to programs. The steps are:
@@ -428,6 +429,7 @@ const REPLACEMENTS = {
   // 6. Replace the node with the original.
   // 7. In hot mode, remove the app from the list of mounted apps.
   // Note: For `Browser.application`, we should ideally remove the 'popstate' and 'hashchange' listeners on `window` as well, but it’s a bit complicated.
+  // Inspired by https://github.com/lamdera/compiler/blob/b3514260acecbedb3289d7f0c7386dcf174de59a/extra/Lamdera/Injection.hs#L625-L689
   _Platform_initialize: (_, start, returnValue, end) => `${start}
   var app = ${returnValue};
   app.unmount = function () {


### PR DESCRIPTION
Steps to reproduce:

1. `cd examples/05-application/`
2. `npm run dev`
3. Open the site in the browser.
4. Click “Counter”.
5. Edit `examples/05-application/src/Pages/Counter.elm` and change the number in `init`.
6. Notice how the page does not update. (It should refresh the page, it works in `examples/03-element/`.)
7. Refresh the page.
8. Notice how you get the new initial value now.
9. Update the number in `init` again.
10. Notice how the page does not update, and how you get the following error in the browser console: `Uncaught (in promise) TypeError: can't access property "removeChildren", scope.domNode is undefined`

This happens because `scope.domNode` is never set for `Browser.document` and `Browser.application` programs.

This PR makes the patching more robust overall:

- Get rid of `scope.domNode` (and the “TODO: Symbol me” comment), and keep track of it like Lamdera does instead (see links in the code comments), in a way that works for all program types.
- Do the replacements like elm-watch does, which guarantees that we never replace things inside strings that the user might have written.
- Use a more elaborate `unmount` implementation, inspired by Lamdera.
- Fix the typo in `if (node.removeChildren) node.replaceChildren()` – we check for the non-existent `node.removeChildren` method, which means that the real `node.replaceChildren()` never runs.