### PR TITLE
Fix React again

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -442,7 +442,6 @@ const REPLACEMENTS = {
     model = null;
     stepper = null;
     ports = null;
-    _Platform_effectManagers = {};
     var node = _VirtualDom_lastDomNode;
     _VirtualDom_lastDomNode = null;
     if (node.elmFs) {


### PR DESCRIPTION
https://github.com/ryan-haskell/vite-plugin-elm-watch/pull/7 accidentally broke React again.

Well, to be completely exact, it didn’t only break React, but any setup that mounts and unmounts Elm apps – which people basically never do usually, but is something that happens a lot in React.

This PR removes `_Platform_effectManagers = {};` from the unmount code. I stole that line from Lamdera (https://github.com/lamdera/compiler/blob/b3514260acecbedb3289d7f0c7386dcf174de59a/extra/Lamdera/Injection.hs#L688). In Lamdera it makes sense, since it is replacing the Elm code with new Elm code. But in our case, the same Elm code is around and needs to be able to mount new apps. So modifying the “global” `_Platform_effectManagers` variable is not a good idea :)