### PR TITLE
Switch to @lydell/elm

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
       "version": "1.4.0",
       "license": "ISC",
       "dependencies": {
+        "@lydell/elm": "0.19.1-14",
         "cross-spawn": "7.0.6",
-        "elm": "0.19.1-6",
         "launch-editor": "2.6.1",
         "terser": "5.26.0",
         "tiny-decoders": "7.0.1"
@@ -18,54 +18,6 @@
       "devDependencies": {
         "vite": "^5.3.5"
       }
-    },
-    "node_modules/@elm_binaries/darwin_arm64": {
-      "version": "0.19.1-0",
-      "resolved": "https://registry.npmjs.org/@elm_binaries/darwin_arm64/-/darwin_arm64-0.19.1-0.tgz",
-      "integrity": "sha512-mjbsH7BNHEAmoE2SCJFcfk5fIHwFIpxtSgnEAqMsVLpBUFoEtAeX+LQ+N0vSFJB3WAh73+QYx/xSluxxLcL6dA==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "darwin"
-      ]
-    },
-    "node_modules/@elm_binaries/darwin_x64": {
-      "version": "0.19.1-0",
-      "resolved": "https://registry.npmjs.org/@elm_binaries/darwin_x64/-/darwin_x64-0.19.1-0.tgz",
-      "integrity": "sha512-QGUtrZTPBzaxgi9al6nr+9313wrnUVHuijzUK39UsPS+pa+n6CmWyV/69sHZeX9qy6UfeugE0PzF3qcUiy2GDQ==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "darwin"
-      ]
-    },
-    "node_modules/@elm_binaries/linux_x64": {
-      "version": "0.19.1-0",
-      "resolved": "https://registry.npmjs.org/@elm_binaries/linux_x64/-/linux_x64-0.19.1-0.tgz",
-      "integrity": "sha512-T1ZrWVhg2kKAsi8caOd3vp/1A3e21VuCpSG63x8rDie50fHbCytTway9B8WHEdnBFv4mYWiA68dzGxYCiFmU2w==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@elm_binaries/win32_x64": {
-      "version": "0.19.1-0",
-      "resolved": "https://registry.npmjs.org/@elm_binaries/win32_x64/-/win32_x64-0.19.1-0.tgz",
-      "integrity": "sha512-yDleiXqSE9EcqKtd9SkC/4RIW8I71YsXzMPL79ub2bBPHjWTcoyyeBbYjoOB9SxSlArJ74HaoBApzT6hY7Zobg==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
-      ]
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.21.5",
@@ -510,6 +462,95 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@lydell/elm": {
+      "version": "0.19.1-14",
+      "resolved": "https://registry.npmjs.org/@lydell/elm/-/elm-0.19.1-14.tgz",
+      "integrity": "sha512-otpGlYiNRvL7F9k6MJOTcuyIgHr+XWy/1NtHpGUgQi8lHrnuyCjwKFPPiimKpr3bcZTwpD4nebHuYR0bmPIKuA==",
+      "hasInstallScript": true,
+      "bin": {
+        "elm": "bin/elm"
+      },
+      "optionalDependencies": {
+        "@lydell/elm_darwin_arm64": "0.19.1-3",
+        "@lydell/elm_darwin_x64": "0.19.1-2",
+        "@lydell/elm_linux_arm": "0.19.1-0",
+        "@lydell/elm_linux_arm64": "0.19.1-4",
+        "@lydell/elm_linux_x64": "0.19.1-1",
+        "@lydell/elm_win32_x64": "0.19.1-1"
+      }
+    },
+    "node_modules/@lydell/elm_darwin_arm64": {
+      "version": "0.19.1-3",
+      "resolved": "https://registry.npmjs.org/@lydell/elm_darwin_arm64/-/elm_darwin_arm64-0.19.1-3.tgz",
+      "integrity": "sha512-RuKTz5ck+RBx4urj1EL/r0xWZZqBMPEXzNBQTEBCAMWLSi4Ck3TVz5pkhBaK+cRZXI+cCgytm/1bIttbp2fFIg==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@lydell/elm_darwin_x64": {
+      "version": "0.19.1-2",
+      "resolved": "https://registry.npmjs.org/@lydell/elm_darwin_x64/-/elm_darwin_x64-0.19.1-2.tgz",
+      "integrity": "sha512-MXfQwxdQfmuQ22iDCFlcXu5YTA0w6/ASzbxmWc+8DkgUkHTynjViGBVkQljAbYe4ZWgrYGWinZQQyhVnp/5oZw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@lydell/elm_linux_arm": {
+      "version": "0.19.1-0",
+      "resolved": "https://registry.npmjs.org/@lydell/elm_linux_arm/-/elm_linux_arm-0.19.1-0.tgz",
+      "integrity": "sha512-crKrLzuT6jn4OOS7PWKZGYFw6vHwPu3iNP7lg8rFkOog/HxlkRwX4S695aILBG8SGTLhEdfP9tg28SQ7vR4Lpg==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@lydell/elm_linux_arm64": {
+      "version": "0.19.1-4",
+      "resolved": "https://registry.npmjs.org/@lydell/elm_linux_arm64/-/elm_linux_arm64-0.19.1-4.tgz",
+      "integrity": "sha512-JuUkkVBtJjUajtTriQFFANHDmwA14NhqNqgIcq5LCJ6vUQv5/LVd6NUOkl/Rdq7Ju/VN/XwBD1/vm7MGIMOTqA==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@lydell/elm_linux_x64": {
+      "version": "0.19.1-1",
+      "resolved": "https://registry.npmjs.org/@lydell/elm_linux_x64/-/elm_linux_x64-0.19.1-1.tgz",
+      "integrity": "sha512-1Y8UAb+GfUqlSjUTX9CaaZhJqvhVcfNbYC0N9AEutlXf1CzFMvF4VsDeZdxzhNI4allPRWBD1IqtdlLhBTFacA==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@lydell/elm_win32_x64": {
+      "version": "0.19.1-1",
+      "resolved": "https://registry.npmjs.org/@lydell/elm_win32_x64/-/elm_win32_x64-0.19.1-1.tgz",
+      "integrity": "sha512-3LMiJ+uUxDFLNnCd6HBmvVWSjSWjs/Z9dMXZWCMOcw3vrW9iOkRrsNGNxohRXun2YRd8wXOX8/DwVn8i2SJ3KA==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.32.0",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.32.0.tgz",
@@ -816,24 +857,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/elm": {
-      "version": "0.19.1-6",
-      "resolved": "https://registry.npmjs.org/elm/-/elm-0.19.1-6.tgz",
-      "integrity": "sha512-mKYyierHICPdMx/vhiIacdPmTPnh889gjHOZ75ZAoCxo3lZmSWbGP8HMw78wyctJH0HwvTmeKhlYSWboQNYPeQ==",
-      "hasInstallScript": true,
-      "bin": {
-        "elm": "bin/elm"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      },
-      "optionalDependencies": {
-        "@elm_binaries/darwin_arm64": "0.19.1-0",
-        "@elm_binaries/darwin_x64": "0.19.1-0",
-        "@elm_binaries/linux_x64": "0.19.1-0",
-        "@elm_binaries/win32_x64": "0.19.1-0"
       }
     },
     "node_modules/esbuild": {
@@ -1157,30 +1180,6 @@
     }
   },
   "dependencies": {
-    "@elm_binaries/darwin_arm64": {
-      "version": "0.19.1-0",
-      "resolved": "https://registry.npmjs.org/@elm_binaries/darwin_arm64/-/darwin_arm64-0.19.1-0.tgz",
-      "integrity": "sha512-mjbsH7BNHEAmoE2SCJFcfk5fIHwFIpxtSgnEAqMsVLpBUFoEtAeX+LQ+N0vSFJB3WAh73+QYx/xSluxxLcL6dA==",
-      "optional": true
-    },
-    "@elm_binaries/darwin_x64": {
-      "version": "0.19.1-0",
-      "resolved": "https://registry.npmjs.org/@elm_binaries/darwin_x64/-/darwin_x64-0.19.1-0.tgz",
-      "integrity": "sha512-QGUtrZTPBzaxgi9al6nr+9313wrnUVHuijzUK39UsPS+pa+n6CmWyV/69sHZeX9qy6UfeugE0PzF3qcUiy2GDQ==",
-      "optional": true
-    },
-    "@elm_binaries/linux_x64": {
-      "version": "0.19.1-0",
-      "resolved": "https://registry.npmjs.org/@elm_binaries/linux_x64/-/linux_x64-0.19.1-0.tgz",
-      "integrity": "sha512-T1ZrWVhg2kKAsi8caOd3vp/1A3e21VuCpSG63x8rDie50fHbCytTway9B8WHEdnBFv4mYWiA68dzGxYCiFmU2w==",
-      "optional": true
-    },
-    "@elm_binaries/win32_x64": {
-      "version": "0.19.1-0",
-      "resolved": "https://registry.npmjs.org/@elm_binaries/win32_x64/-/win32_x64-0.19.1-0.tgz",
-      "integrity": "sha512-yDleiXqSE9EcqKtd9SkC/4RIW8I71YsXzMPL79ub2bBPHjWTcoyyeBbYjoOB9SxSlArJ74HaoBApzT6hY7Zobg==",
-      "optional": true
-    },
     "@esbuild/aix-ppc64": {
       "version": "0.21.5",
       "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
@@ -1385,6 +1384,55 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "@lydell/elm": {
+      "version": "0.19.1-14",
+      "resolved": "https://registry.npmjs.org/@lydell/elm/-/elm-0.19.1-14.tgz",
+      "integrity": "sha512-otpGlYiNRvL7F9k6MJOTcuyIgHr+XWy/1NtHpGUgQi8lHrnuyCjwKFPPiimKpr3bcZTwpD4nebHuYR0bmPIKuA==",
+      "requires": {
+        "@lydell/elm_darwin_arm64": "0.19.1-3",
+        "@lydell/elm_darwin_x64": "0.19.1-2",
+        "@lydell/elm_linux_arm": "0.19.1-0",
+        "@lydell/elm_linux_arm64": "0.19.1-4",
+        "@lydell/elm_linux_x64": "0.19.1-1",
+        "@lydell/elm_win32_x64": "0.19.1-1"
+      }
+    },
+    "@lydell/elm_darwin_arm64": {
+      "version": "0.19.1-3",
+      "resolved": "https://registry.npmjs.org/@lydell/elm_darwin_arm64/-/elm_darwin_arm64-0.19.1-3.tgz",
+      "integrity": "sha512-RuKTz5ck+RBx4urj1EL/r0xWZZqBMPEXzNBQTEBCAMWLSi4Ck3TVz5pkhBaK+cRZXI+cCgytm/1bIttbp2fFIg==",
+      "optional": true
+    },
+    "@lydell/elm_darwin_x64": {
+      "version": "0.19.1-2",
+      "resolved": "https://registry.npmjs.org/@lydell/elm_darwin_x64/-/elm_darwin_x64-0.19.1-2.tgz",
+      "integrity": "sha512-MXfQwxdQfmuQ22iDCFlcXu5YTA0w6/ASzbxmWc+8DkgUkHTynjViGBVkQljAbYe4ZWgrYGWinZQQyhVnp/5oZw==",
+      "optional": true
+    },
+    "@lydell/elm_linux_arm": {
+      "version": "0.19.1-0",
+      "resolved": "https://registry.npmjs.org/@lydell/elm_linux_arm/-/elm_linux_arm-0.19.1-0.tgz",
+      "integrity": "sha512-crKrLzuT6jn4OOS7PWKZGYFw6vHwPu3iNP7lg8rFkOog/HxlkRwX4S695aILBG8SGTLhEdfP9tg28SQ7vR4Lpg==",
+      "optional": true
+    },
+    "@lydell/elm_linux_arm64": {
+      "version": "0.19.1-4",
+      "resolved": "https://registry.npmjs.org/@lydell/elm_linux_arm64/-/elm_linux_arm64-0.19.1-4.tgz",
+      "integrity": "sha512-JuUkkVBtJjUajtTriQFFANHDmwA14NhqNqgIcq5LCJ6vUQv5/LVd6NUOkl/Rdq7Ju/VN/XwBD1/vm7MGIMOTqA==",
+      "optional": true
+    },
+    "@lydell/elm_linux_x64": {
+      "version": "0.19.1-1",
+      "resolved": "https://registry.npmjs.org/@lydell/elm_linux_x64/-/elm_linux_x64-0.19.1-1.tgz",
+      "integrity": "sha512-1Y8UAb+GfUqlSjUTX9CaaZhJqvhVcfNbYC0N9AEutlXf1CzFMvF4VsDeZdxzhNI4allPRWBD1IqtdlLhBTFacA==",
+      "optional": true
+    },
+    "@lydell/elm_win32_x64": {
+      "version": "0.19.1-1",
+      "resolved": "https://registry.npmjs.org/@lydell/elm_win32_x64/-/elm_win32_x64-0.19.1-1.tgz",
+      "integrity": "sha512-3LMiJ+uUxDFLNnCd6HBmvVWSjSWjs/Z9dMXZWCMOcw3vrW9iOkRrsNGNxohRXun2YRd8wXOX8/DwVn8i2SJ3KA==",
+      "optional": true
+    },
     "@rollup/rollup-android-arm-eabi": {
       "version": "4.32.0",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.32.0.tgz",
@@ -1547,17 +1595,6 @@
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
         "which": "^2.0.1"
-      }
-    },
-    "elm": {
-      "version": "0.19.1-6",
-      "resolved": "https://registry.npmjs.org/elm/-/elm-0.19.1-6.tgz",
-      "integrity": "sha512-mKYyierHICPdMx/vhiIacdPmTPnh889gjHOZ75ZAoCxo3lZmSWbGP8HMw78wyctJH0HwvTmeKhlYSWboQNYPeQ==",
-      "requires": {
-        "@elm_binaries/darwin_arm64": "0.19.1-0",
-        "@elm_binaries/darwin_x64": "0.19.1-0",
-        "@elm_binaries/linux_x64": "0.19.1-0",
-        "@elm_binaries/win32_x64": "0.19.1-0"
       }
     },
     "esbuild": {

--- a/package.json
+++ b/package.json
@@ -24,8 +24,8 @@
   },
   "homepage": "https://github.com/ryannhg/vite-plugin-elm-watch#readme",
   "dependencies": {
+    "@lydell/elm": "0.19.1-14",
     "cross-spawn": "7.0.6",
-    "elm": "0.19.1-6",
     "launch-editor": "2.6.1",
     "terser": "5.26.0",
     "tiny-decoders": "7.0.1"


### PR DESCRIPTION
elm-land uses the `@lydell/elm` npm package rather than `elm`: https://github.com/elm-land/elm-land/commit/779db280150af259093d66bb1b0df57523c8754d

Currently, when you install `elm-land`, you also install the Elm binary … _twice._ Once via the `@lydell/elm` package that elm-land depends on, and once via the `elm` package that `vite-plugin-elm-watch` depends on.

Here’s an elm-land user that would have benefitted from us only depending on `@lydell/elm`: https://discourse.elm-lang.org/t/elm-on-arm-linux-on-parallels-on-macos/10106

Now that I think about it … why does `elm-land` even depend on `@lydell/elm`? Isn’t it enough that `vite-plugin-elm-watch` depends on it?